### PR TITLE
Fixing NCCH flag detection code for zerokey

### DIFF
--- a/3dsconv.py
+++ b/3dsconv.py
@@ -225,8 +225,12 @@ for rom in files:
         dlpchildcfa_size = struct.unpack("<I", romf.read(4))[0] * mu
 
         romf.seek(gamecxi_offset + 0x18F)
-        decrypted = int(binascii.hexlify(romf.read(1))) & 0x04
-        zerokey_enc = int(binascii.hexlify(romf.read(1))) & 0x01
+
+        # Check NCCH flag 7 for FixedCryptoKey (0x1) and NoCrypto (0x4)
+        bitmask = int(binascii.hexlify(romf.read(1)))
+        decrypted = bitmask & 0x4
+        zerokey_enc = bitmask & 0x1
+
         print("- processing: {} ({})".format(
             rom[1], "decrypted" if decrypted else ("zerokey" if zerokey_enc else "encrypted")
         ))


### PR DESCRIPTION
Problem:
Encrypted CCIs no longer work with 3dsconv.py. All xorpads are incorrectly displayed as corrupt or a mismatch.

Analysis:
The recently-committed code that checked the NCCH flags for zerokey encryption was calling read(1) once for each flag comparison, which resulted in the wrong byte being used for comparison in the second case. As a result, all encrypted CCIs are incorrectly flagged as being encrypted with a fixed/zero key.

This commit stores the bitmask in a temporary variable instead. Encrypted CCIs are now properly detected and packed as expected.