### PR TITLE
Adding recursive xorpad file search and crc32 support

### DIFF
--- a/3dsconv.py
+++ b/3dsconv.py
@@ -15,6 +15,18 @@ import struct
 import sys
 import zlib
 
+
+def get_file_crc32(path):
+  chunksize = 1024 * 1024
+  buf = open(path, 'rb')
+  chunk = buf.read(chunksize)
+  crc = 0
+  while chunk:
+    crc = zlib.crc32(chunk, crc)
+    chunk = buf.read(chunksize)
+  crc = crc & 0xffffffff
+  return "%08x" % crc
+
 # check for PyCrypto, which is used for zerokey support
 pycrypto_found = False
 try:
@@ -160,6 +172,22 @@ def showprogress(val, maxval):
     sys.stdout.write("\r  {:>5.1f}% {:>10} / {}".format((minval / maxval) * 100, minval, maxval))
     sys.stdout.flush()
 
+def find_xorpad_file(search_path, xorpad_default, xorpad_with_crc32):
+  xorpad = False
+
+  for root, dirnames, filenames in os.walk(search_path):
+    for filename in filenames:
+      if filename.lower() == xorpad_with_crc32.lower():
+        # exact match with crc32.
+        return os.path.join(root, filename)
+
+      if filename.lower() == xorpad_default.lower():
+        # title match, but could potentially still see an exact crc32 match.
+        xorpad = os.path.join(root, filename)
+
+  return xorpad
+
+
 totalroms = 0
 processedroms = 0
 
@@ -199,6 +227,12 @@ for rom in files:
     if genncchinfo and genncchall:
         ncchinfoadd(rom[0])
     totalroms += 1
+
+    print("- opening %s" % rom[0])
+
+    print("- calculating crc32...")
+    crc32 = get_file_crc32(rom[0])
+
     with open(rom[0], "rb") as romf:
         romf.seek(0x100)
         ncsdmagic = romf.read(4)
@@ -209,7 +243,13 @@ for rom in files:
         romf.seek(0x108)
         tid_bin = romf.read(8)[::-1]
         tid = binascii.hexlify(tid_bin)
-        xorpad = os.path.join(xorpad_directory, "{}.Main.exheader.xorpad".format(tid.upper()))
+
+        xorpad_default = '%s.Main.exheader.xorpad' % tid.upper()
+        xorpad_with_crc32 = '%s.%s.Main.exheader.xorpad' % (tid.upper(), crc32)
+        xorpad = find_xorpad_file(xorpad_directory, xorpad_default, xorpad_with_crc32)
+        if xorpad:
+          print("- found xorpad file %s" % os.path.basename(xorpad))
+
 
         # find Game Executable CXI
         romf.seek(0x120)
@@ -242,8 +282,8 @@ for rom in files:
                 ncchinfoadd(rom[0])
             continue
         if not decrypted and not zerokey_enc:
-            if not os.path.isfile(xorpad):
-                print("! {} couldn't be found.".format(xorpad))
+            if not xorpad:
+                print("! no xorpad file found. looking for %s or %s" % (xorpad_default, xorpad_with_crc32))
                 if not genncchinfo:
                     print("  use --gen-ncchinfo with this CCI.")
                 else:


### PR DESCRIPTION
Summary:
  Many xorpad repos/distributions now include the CRC32 of the title in the filename. In many cases the xorpad files are also split into multiple subfolders. Currently, 3dsconv will not discover xorpad files in subdirectories or with crc32 info in their filename. In some cases, titles may have multiple revisions. By calculating the crc32 of the input file we can more accurately find its related xorpad.

Changes:
  - The xorpad directory is now searched recursively for xorpad files
  - xorpad files are searched in a case-insensitive fashion
  - Discover and prefer xorpad files with matching crc32 in the filename

Extra info:
  I wrote the CRC32 function included here for minimal memory use and high speed. zlib is about 5x faster than using binascii.crc32.