### PR TITLE
Add main method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.xorpad
 *.exe
 *.bin
+*.egg-info
 ncchinfo.bin
 work/
 test/

--- a/3dsconv/3dsconv.py
+++ b/3dsconv/3dsconv.py
@@ -15,6 +15,9 @@ import struct
 import sys
 import zlib
 
+def main():
+    pass
+
 # check for pyaes which is used for crypto
 pyaes_found = False
 try:

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(
     description='Converts Nintendo 3DS CTR Cart Image files (CCI, ".cci", ".3ds") to the CTR Importable Archive format (CIA)',
     install_requires=['pyaes'],
     packages=find_packages(),
-    entry_points={'console_scripts': ['3dsconv=3dsconv.3dsconv']},
+    entry_points={'console_scripts': ['3dsconv=3dsconv.3dsconv:main']},
 )


### PR DESCRIPTION
* Add a main method to 3dsconv.py to ensure there is no ugly Error when
using 3dsconv after installing with setuptools.
* Added *.egg-info to gitignore


If you use 3dsconv installed with setuptool there is a error after the script is finished. The function of the script is not impaired by this error. It's just ugly.
>$ 3dsconv --overwrite XXX.3ds
> 3dsconv.py ~ version 4.2dev
> Converting XXX (encrypted)...
> Writing Game Executable CXI...
>   100.0%   86785024 / 86785024
> Done converting 1 out of 1 files.
> Traceback (most recent call last):
>   File "/usr/local/bin/3dsconv", line 11, in <module>
>     load_entry_point('3dsconv==4.2.dev0', 'console_scripts', '3dsconv')()
> TypeError: 'module' object is not callable

Also I added *.egg-info to gitignore as it's generated by setuptools.

This commit doesn't change any functions. The script can still be used without installing it.

Please excuse my mistake, not seeing this error before I sent the last PR.

Cheers