### PR TITLE
Added small fix for getting boot9 file location from environment

### DIFF
--- a/3dsconv/3dsconv.py
+++ b/3dsconv/3dsconv.py
@@ -19,6 +19,9 @@ import zlib
 def main():
     pass
 
+def chb9(namevar):
+    if os.environ[namevar] != None:
+        boot9_path = os.environ[namevar]
 
 # check for pyaes which is used for crypto
 pyaes_found = False
@@ -31,6 +34,7 @@ except ImportError:
 # default paths, relative to cwd
 output_directory = ''  # override with --output=
 boot9_path = ''  # override with --boot9=
+chb9('BOOT9_PATH')
 
 version = '4.21'
 


### PR DESCRIPTION
This fix improves compatibility with [ninfs](https://github.com/ihaveamac/ninfs) by getting boot9 path from the same environment variable