### PR TITLE
fix the console entry point script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+__pycache__/
+
 # ignore roms and stuff
 *.3ds
 *.cci

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,6 @@ setup(
     description='Converts Nintendo 3DS CTR Cart Image files (CCI, ".cci", ".3ds") to the CTR Importable Archive format (CIA)',
     install_requires=['pyaes'],
     packages=find_packages(),
-    entry_points={'console_scripts': ['3dsconv=3dsconv.3dsconv:main']},
+    py_modules=['threedsconv'],
+    entry_points={'console_scripts': ['3dsconv=threedsconv:main']},
 )

--- a/threedsconv.py
+++ b/threedsconv.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+def main():
+	__import__('3dsconv.3dsconv')
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
The console entry point was failing because the generated code contained "from 3dsconv.3dsconv import main" which is invalid syntax.

## Problem steps

1. `pip install .`
2. `3dsconv`

## Expected behavior

A help message is displayed.

## Actual behavior

SyntaxError: invalid syntax