### PR TITLE
Use argparse for argument parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ work/
 test/
 build/
 dist/
+*__pycache__*
 
 # Created by .ignore support plugin (hsz.mobi)
 ### JetBrains template


### PR DESCRIPTION
## Notes
* Manual argument parsing and construction of help messages makes future updates, bug fixes, and feature additions more time consuming and error prone to introduce.
* Replaced manual argument parsing with argparse
* Removed `boot9_found` as it is completely unused
* Added `*__pycache__*` to .gitignore

## Testing
* Ran without arguments to ensure a similar, tho not identical, help message is printed.
  * Original:
    ```
    $ 3dsconv 
    3dsconv.py ~ version 4.21
    Convert Nintendo 3DS CCI (.3ds/.cci) to CIA
    https://github.com/ihaveamac/3dsconv

    Usage: /usr/local/bin/3dsconv [options] <game> [<game>...]

    Options:
      --output=<dir>       - Save converted files in specified directory
                               Default: current directory
      --boot9=<file>       - Path to dump of ARM9 bootROM, protected or full
      --overwrite          - Overwrite existing converted files
      --ignore-bad-hashes  - Ignore invalid hashes and CCI files and convert anyway
      --ignore-encryption  - Ignore the encryption header value, assume the ROM as unencrypted
      --verbose            - Print more information
      --dev-keys           - Use developer-unit keys
    ```
  * This change:
    ```
    $ ./3dsconv.py 
    usage: 3dsconv.py [-h] [-o output-directory] [-b path-to-boot9] [--overwrite] [--ignore-bad-hashes] [--ignore-encryption] [-v] [--dev-keys] game [game ...]

    Convert Nintendo 3DS CCI (.3ds/.cci) to CIA

    positional arguments:
      game                  Game file to convert to CIA

    options:
      -h, --help            show this help message and exit
      -o output-directory, --output output-directory
                            Save converted files in specified directory (default: current directory)
      -b path-to-boot9, --boot9 path-to-boot9
                            Path to dump of ARM9 bootROM, protected or full
      --overwrite           Overwrite existing converted files
      --ignore-bad-hashes   Ignore invalid hashes and CCI files and convert anyway
      --ignore-encryption   Ignore the encryption header value, assume the ROM as unencrypted
      -v, --verbose         Print more information
      --dev-keys            Use developer-unit keys
    ```
* Ran tool against .3ds files to convert them to .cia to ensure existing functionality was not negatively impacted.